### PR TITLE
Container binds on ip of hostname by default

### DIFF
--- a/src/main/java/net/technolords/util/AugmentProperties.java
+++ b/src/main/java/net/technolords/util/AugmentProperties.java
@@ -57,10 +57,8 @@ public class AugmentProperties {
         // Assert correct defaults
         boolean changed = this.checkDefaults(serverProperties);
         // Assert environment variables
-        changed |= this.parseEnvironmentVariables(serverProperties);
-        if (changed) {
-            this.storePropertiesAsFile(serverProperties, pathToServerProperties);
-        }
+        this.parseEnvironmentVariables(serverProperties);
+        this.storePropertiesAsFile(serverProperties, pathToServerProperties);
     }
 
     /**
@@ -171,7 +169,7 @@ public class AugmentProperties {
         boolean ssl = false;
         for (String key : environmentMap.keySet()) {
             // When a keystore location is defined, it means kafka (must) run as secure
-            if (key.toLowerCase().equals("ssl.keystore.location")) {
+            if (key.toLowerCase().equals("kafka.ssl.keystore.location")) {
                 ssl = true;
                 break;
             }

--- a/src/main/java/net/technolords/util/AugmentProperties.java
+++ b/src/main/java/net/technolords/util/AugmentProperties.java
@@ -2,6 +2,8 @@ package net.technolords.util;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -180,6 +182,12 @@ public class AugmentProperties {
             buffer.append("PLAINTEXT://");
         }
         String hostname = environmentMap.get(ENV_HOSTNAME);
+        try {
+            InetAddress address = InetAddress.getByName(hostname);
+            hostname = address.getHostAddress();
+        } catch (UnknownHostException e) {
+            LOGGER.warn("Unable to resolve address '{}' to ip...", hostname);
+        }
         buffer.append(hostname);
         buffer.append(":9092");
         LOGGER.info("Found HOSTNAME: {} -> (advertised)listener: {}", hostname, buffer.toString());

--- a/src/test/java/net/technolords/util/AugmentPropertiesTest.java
+++ b/src/test/java/net/technolords/util/AugmentPropertiesTest.java
@@ -2,6 +2,8 @@ package net.technolords.util;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.Map;
@@ -15,6 +17,14 @@ import org.testng.annotations.Test;
 public class AugmentPropertiesTest {
     private final Logger LOGGER = LoggerFactory.getLogger(getClass());
     public static final String TEST_PROPERTIES = "src/test/resources/source/server.properties";
+
+    @Test
+    public void testHostnameToAddress() throws UnknownHostException {
+        LOGGER.info("About to test hostname to address");
+        String hostname = "localhost";
+        InetAddress address = InetAddress.getByName(hostname);
+        LOGGER.info("InetAddress: {}", address.getHostAddress());
+    }
 
     @Test
     public void testReadProperties() throws IOException {


### PR DESCRIPTION
This pull request solves an issue for particular type of deployments, for example in Openshift/Kubernetes. Kafka requires a routable ip (and fails to bind on 0.0.0.0 and 127.0.0.1 is not desirable).

Now it will bind on the ip derived from the HOSTNAME being present as environment variable at OS level, as a better default.